### PR TITLE
manjaro-lxde-settings: Select freenode by default and change nick name for Hexchat

### DIFF
--- a/community/lxde/skel/.config/hexchat/hexchat.conf
+++ b/community/lxde/skel/.config/hexchat/hexchat.conf
@@ -1,1 +1,4 @@
 gui_slist_select = 29
+irc_nick1 = manjaroLXDE
+irc_nick2 = manjaroLXDE_
+irc_nick3 = manjaroLXDE__

--- a/community/lxde/skel/.config/hexchat/hexchat.conf
+++ b/community/lxde/skel/.config/hexchat/hexchat.conf
@@ -1,0 +1,1 @@
+gui_slist_select = 29


### PR DESCRIPTION
I had already added **#manjaro** and **#manjaro-talk** channels but I didn't change hexchat to select **freenode** by default. There is a chance, that a user who might need help on the IRC to forget in which server the manjaro channels belong. The rest hexchat settings which aren't included at **hexchat.conf** will just be set to default settings when hexchat is run for the 1st time.