### PR TITLE
Some changes for manjaro-lxde-settings

### DIFF
--- a/community/lxde/skel/.config/openbox/lxde-rc.xml
+++ b/community/lxde/skel/.config/openbox/lxde-rc.xml
@@ -419,7 +419,7 @@
         </keybind>
         <keybind key="XF86AudioRaiseVolume">
           <action name="Execute">
-            <command>amixer set Master 5%+ unmute</command>
+            <command>pulseaudio-ctl up</command>
             <startupnotify>
               <enabled>yes</enabled>
               <name>Increase Audio Volume</name>
@@ -428,7 +428,7 @@
         </keybind>
         <keybind key="XF86AudioLowerVolume">
           <action name="Execute">
-            <command>amixer set Master 5%- unmute</command>
+            <command>pulseaudio-ctl down</command>
             <startupnotify>
               <enabled>yes</enabled>
               <name>Decrease Audio Volume</name>

--- a/community/lxde/skel/.config/openbox/lxde-rc.xml
+++ b/community/lxde/skel/.config/openbox/lxde-rc.xml
@@ -435,24 +435,6 @@
             </startupnotify>
           </action>
         </keybind>
-        <keybind key="XF86MonBrightnessDown">
-          <action name="Execute">
-            <command>xbacklight -20</command>
-            <startupnotify>
-              <enabled>yes</enabled>
-              <name>Decrease screen brightness</name>
-            </startupnotify>
-          </action>
-        </keybind>
-        <keybind key="XF86MonBrightnessUp">
-          <action name="Execute">
-            <command>xbacklight +20</command>
-            <startupnotify>
-              <enabled>yes</enabled>
-              <name>Increase screen brightness</name>
-            </startupnotify>
-          </action>
-        </keybind>
     </keyboard>
     <mouse>
         <dragThreshold>8</dragThreshold>

--- a/community/lxde/skel/.config/pulseaudio-ctl/config
+++ b/community/lxde/skel/.config/pulseaudio-ctl/config
@@ -1,0 +1,22 @@
+#
+# $HOME/.config/pulseaudio-ctl/config
+#
+
+# The default setting is for pulseaudio-ctl to NOT increase to volume level
+# above 100 % but Some users may wish exceed this level. If this describes
+# your use case, uncomment the UPPER_THRESHOLD variable below setting it to
+# the new upper threshold.
+# 
+#UPPER_THRESHOLD=150
+
+# Push output through libnotify. Set to any value to enable this feature
+# and note that you must have /usr/bin/notify-send to use this. On Arch
+# libnotify provides this. Other distros may not name it as such.
+#
+NOTIFY=yes
+
+# Show a graphical progress-bar type visualization of the volume level in
+# libnotify. No setting or commented out will show a simply percentage but
+# a setting will convert the percentage to a progress-bar in libnotify.
+#
+#BARCHART=yes

--- a/community/lxde/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml
+++ b/community/lxde/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<channel name="xfce4-power-manager" version="1.0">
+  <property name="xfce4-power-manager" type="empty">
+    <property name="brightness-switch-restore-on-exit" type="int" value="0"/>
+    <property name="brightness-switch" type="int" value="0"/>
+    <property name="general-notification" type="bool" value="true"/>
+    <property name="show-tray-icon" type="bool" value="true"/>
+    <property name="handle-brightness-keys" type="bool" value="true"/>
+  </property>
+</channel>


### PR DESCRIPTION
1. Use keybind for changing volume with command **pulseaudio-ctl** and show notifications.
2. Remove openbox keybinds for brightness (which don't work properly) and let **xfce4-power-manager** handle brightness keys.