### PR TITLE
Lxde: add keybindings for tiling on edges and top-bottom halves with Super+Arrows

### DIFF
--- a/community/lxde/skel/.config/openbox/lxde-rc.xml
+++ b/community/lxde/skel/.config/openbox/lxde-rc.xml
@@ -417,6 +417,42 @@
                 <height>50%</height>
             </action>
         </keybind>
+        <keybind key='W-Left'>
+             <action name='Unmaximize'/>
+            <action name='MoveResizeTo'>
+                <x>0</x>
+                <y>0</y>
+                <width>50%</width>
+                <height>100%</height>
+            </action>
+        </keybind>
+        <keybind key='W-Down'>
+            <action name='Unmaximize'/>
+            <action name='MoveResizeTo'>
+                <x>0</x>
+                <y>-0</y>
+                <width>100%</width>
+                <height>50%</height>
+            </action>
+        </keybind>
+        <keybind key='W-Right'>
+            <action name='Unmaximize'/>
+            <action name='MoveResizeTo'>
+                <x>-0</x>
+                <y>0</y>
+                <width>50%</width>
+                <height>100%</height>
+            </action>
+        </keybind>
+        <keybind key='W-Up'>
+            <action name='Unmaximize'/>
+            <action name='MoveResizeTo'>
+                <x>0</x>
+                <y>0</y>
+                <width>100%</width>
+                <height>50%</height>
+            </action>
+        </keybind>
     </keyboard>
     <mouse>
         <dragThreshold>8</dragThreshold>

--- a/community/lxde/skel/.config/openbox/lxde-rc.xml
+++ b/community/lxde/skel/.config/openbox/lxde-rc.xml
@@ -331,6 +331,16 @@
                 <command>i3-scrot</command>
             </action>
         </keybind>
+        <keybind key='A-Print'>
+            <action name='Execute'>
+                <command>i3-scrot -w</command>
+            </action>
+        </keybind>
+        <keybind key='S-Print'>
+            <action name='Execute'>
+                <command>i3-scrot -s</command>
+            </action>
+        </keybind>
         <keybind key='C-A-t'>
             <action name='Execute'>
                 <command>lxterminal</command>

--- a/community/lxde/skel/.extend.xinitrc
+++ b/community/lxde/skel/.extend.xinitrc
@@ -10,4 +10,3 @@
 export GTK2_RC_FILES="$HOME/.gtkrc-2.0"
 
 DEFAULT_SESSION=startlxde
-exec startlxde

--- a/community/lxde/skel/.extend.xinitrc
+++ b/community/lxde/skel/.extend.xinitrc
@@ -10,6 +10,4 @@
 export GTK2_RC_FILES="$HOME/.gtkrc-2.0"
 
 DEFAULT_SESSION=startlxde
-
-# fix pcmanfm
-dbus-launch pcmanfm
+exec startlxde


### PR DESCRIPTION
Tiling keybinds exist already for Super+Keypad 1-9 (which support tiling at corners too). However, many laptops don't have keypad at all. So, I also added tiling on left,right,top,bottom edges with Super+Arrows.