### PR TITLE
lxde-settings: increase panel size

### DIFF
--- a/community/lxde/skel/.config/lxpanel/LXDE/panels/panel
+++ b/community/lxde/skel/.config/lxpanel/LXDE/panels/panel
@@ -7,7 +7,7 @@ Global {
   margin=0
   widthtype=percent
   width=100
-  height=28
+  height=34
   transparent=0
   tintcolor=#000000
   alpha=0
@@ -19,7 +19,7 @@ Global {
   fontcolor=#ffffff
   background=0
   backgroundfile=/usr/share/lxpanel/images/background.png
-  iconsize=26
+  iconsize=32
   usefontsize=0
 }
 Plugin {


### PR DESCRIPTION
Following the poll from here: https://forum.manjaro.org/t/poll-for-lxde-default-panel-size-and-icons-size/26484, I increased panel size to 34.

Even if the final official releases get out early, I will wait for this change to reach the stable branch before I do the final lxde release.