### PR TITLE
i3: update dunst configuration to support max_icon_size configuration

### DIFF
--- a/community/i3/skel/.config/dunst/dunstrc
+++ b/community/i3/skel/.config/dunst/dunstrc
@@ -150,6 +150,9 @@
     # Paths to default icons.
     icon_folders = /usr/share/icons/Adwaita/16x16/status/:/usr/share/icons/Adwaita/16x16/devices/
 
+    # Limit icons size.
+    max_icon_size=128
+
 [frame]
     width = 1
     color = "#16A085"


### PR DESCRIPTION
Just a small update on dunst configuration. I had an issue with Spotify album covers and Slack team images that take a large portion of the screen. 
I've set max size to 128 pixels arbitrary, but if fit nicely on a 1920x1080 screen. 
This option require dunst 1.2.0 https://dunst-project.org/changelog/
@oberon2007 can you check it please :)