### PR TITLE
i3: Fix blueman applet binary name

### DIFF
--- a/community/i3/skel/.i3/config
+++ b/community/i3/skel/.i3/config
@@ -279,7 +279,7 @@ exec --no-startup-id nm-applet
 exec --no-startup-id xfce4-power-manager
 exec --no-startup-id pamac-tray
 exec --no-startup-id clipit
-# exec --no-startup-id blueman
+# exec --no-startup-id blueman-applet
 # exec_always --no-startup-id sbxkb
 exec --no-startup-id start_conky_maia
 # exec --no-startup-id start_conky_green


### PR DESCRIPTION
It's a comment but the correct executable for the blueman applet is `blueman-applet`