### PR TITLE
added colors to binding mode

### DIFF
--- a/community/i3/skel/.i3/config
+++ b/community/i3/skel/.i3/config
@@ -368,6 +368,7 @@ bar {
         focused_workspace   $i3_color1  $i3_color4  $i3_text
         active_workspace    $i3_color2  $i3_color3  $i3_color5
         inactive_workspace  $i3_color2  $i3_color3  $i3_color6
+	binding_mode        $i3_color4  $i3_color4  $i3_text
         urgent_workspace    $i3_color4  $i3_color5  $i3_color7
     }
 }


### PR DESCRIPTION
I just couldn't stand the urgent colors... each time I went into resize or system mode. So I went to the i3 docs and learnt about this setting that was missing! 

I choose to use the same background color as in focused to attract  eyes attention. Also, I've set the border color the same as in the background in order to make the text more readable. 

Cheers!